### PR TITLE
New mobile navigation overlay

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,24 +1,18 @@
 {
-  "extends": [
-    "eslint:recommended",
-    "plugin:vue/vue3-recommended"
-  ],
+  "extends": ["eslint:recommended", "plugin:vue/vue3-recommended"],
   "rules": {
     "vue/html-closing-bracket-newline": [
       "error",
       {
         "singleline": "never",
-        "multiline": "never"
+        "multiline": "always"
       }
     ],
     "vue/max-attributes-per-line": [
       "error",
       {
         "singleline": 3,
-        "multiline": {
-          "max": 4,
-          "allowFirstLine": true
-        }
+        "multiline": 1
       }
     ],
     "vue/no-v-html": "off",
@@ -27,16 +21,7 @@
       {
         "ignoreWhenNoAttributes": true,
         "ignoreWhenEmpty": true,
-        "ignores": [
-          "h1",
-          "h2",
-          "h3",
-          "h4",
-          "h5",
-          "h6",
-          "a",
-          "span"
-        ]
+        "ignores": ["h1", "h2", "h3", "h4", "h5", "h6", "a", "span"]
       }
     ]
   }

--- a/src/App.vue
+++ b/src/App.vue
@@ -30,7 +30,7 @@ export default {
 html, body {
   height: 100%;
   margin: 0;
-  background-color: $background; 
+  background-color: $background;
 }
 
 a {

--- a/src/assets/css/main.css
+++ b/src/assets/css/main.css
@@ -1,5 +1,4 @@
 
-/* TODO: nowhere used, delete it? */
 .mb-6 {
 margin-bottom: 6rem;
 }

--- a/src/components/Timeline.vue
+++ b/src/components/Timeline.vue
@@ -28,15 +28,14 @@ export default {
   }
 }
 </script>
+
 <style scoped lang="scss">
 #timeline {
   position: relative;
-  /* max-width: 1200px; */
-  /* margin: 0 auto; */
 }
 
 #timeline::after {
-  left: 50%; /*TODO: fix scrollbar extra width*/
+  left: 50%;
   position: absolute;
   width: 4px;
   top: 0;
@@ -53,13 +52,10 @@ export default {
   width: 50%;
 }
 
-
-/* Place the container to the right */
 .post-right {
   left: 50%;
 }
 
-/* Timeline dots  */
 .timeline-post::after {
   position: absolute;
   content: '';
@@ -78,7 +74,6 @@ export default {
 }
 
 @media screen and (max-width: 600px) {
-/* Place the timelime to the left */
   #timeline::after {
     left: 31px;
   }
@@ -96,5 +91,4 @@ export default {
     left: 0;
   }
 }
-
 </style>

--- a/src/components/TimelinePost.vue
+++ b/src/components/TimelinePost.vue
@@ -21,9 +21,9 @@ export default {
   }
 }
 </script>
+
 <style scoped>
 .timeline-post {
   font-size: 0.9em;
 }
 </style>
-

--- a/src/components/card/Card.vue
+++ b/src/components/card/Card.vue
@@ -31,7 +31,6 @@ export default {
 </script>
 
 <style scoped lang="scss">
-
 .card-body {
   padding: 1.5rem;
   background-color: $background;

--- a/src/components/layout/Header.vue
+++ b/src/components/layout/Header.vue
@@ -40,6 +40,9 @@
     id="mobileNavOverlay"
     :class="{ active: isMobileNavActive }"
     class="dark d-lg-none"
+    @scroll.prevent
+    @touchmove.prevent
+    @wheel.prevent
   >
     <div class="blur" />
 
@@ -93,10 +96,6 @@ export default {
   methods: {
     toggleMobileNav: function () {
       this.isMobileNavActive = !this.isMobileNavActive
-
-      document.documentElement.style.overflow = this.isMobileNavActive
-          ? "hidden"
-          : "auto"
     }
   }
 }

--- a/src/components/layout/Header.vue
+++ b/src/components/layout/Header.vue
@@ -8,8 +8,8 @@
 
         <div
           id="button"
-          class="dark d-lg-none"
           :class="{ active: isMobileNavActive }"
+          class="dark d-lg-none"
           @click="toggleMobileNav"
         >
           <span />
@@ -18,8 +18,14 @@
         <div class="collapse navbar-collapse">
           <div class="d-flex flex-grow-1 justify-content-end">
             <ul class="navbar-nav mb-lg-0">
-              <li v-for="view in views" :key="view">
-                <router-link class="nav-link" :to="{ name: view }">
+              <li
+                v-for="view in views"
+                :key="view"
+              >
+                <router-link
+                  class="nav-link"
+                  :to="{ name: view }"
+                >
                   {{ view }}
                 </router-link>
               </li>
@@ -32,18 +38,17 @@
 
   <div
     id="mobileNavOverlay"
-    class="dark d-lg-none"
     :class="{ active: isMobileNavActive }"
+    class="dark d-lg-none"
   >
     <div class="blur" />
+
     <ul class="mb-lg-0">
       <li>
         <router-link
-          class="nav-link"
+          :class="{ 'active': 'Home' === currentRoute }"
           :to="{ name: 'Home' }"
-          :class="{
-            active: 'Home' === currentRoute,
-          }"
+          class="nav-link"
           @click="toggleMobileNav"
         >
           {{ "Home" }}
@@ -51,11 +56,9 @@
       </li>
       <li v-for="view in views" :key="view">
         <router-link
-          class="nav-link"
+          :class="{ 'active': view === currentRoute }"
           :to="{ name: view }"
-          :class="{
-            active: view === currentRoute,
-          }"
+          class="nav-link"
           @click="toggleMobileNav"
         >
           {{ view }}
@@ -66,183 +69,184 @@
 </template>
 
 <script>
-  import content from "@/ressources/components/layout/header.json"
+import content from "@/ressources/components/layout/header.json"
 
-  export default {
-    data: function () {
-      return {
-        isMobileNavActive: false,
-      }
+export default {
+  data: function () {
+    return {
+      isMobileNavActive: false
+    }
+  },
+  computed: {
+    views: function () {
+      return ["About", "Projects", "Blog"]
     },
-    computed: {
-      views: function () {
-        return ["About", "Projects", "Blog"]
-      },
-      currentRoute: {
-        get() {
-          return this.$route.name
-        },
-      },
-      content: function () {
-        return content
+    currentRoute: {
+      get() {
+        return this.$route.name
       },
     },
-    methods: {
-      toggleMobileNav: function () {
-        this.isMobileNavActive = !this.isMobileNavActive
-        document.documentElement.style.overflow = this.isMobileNavActive
+    content: function () {
+      return content
+    },
+  },
+  methods: {
+    toggleMobileNav: function () {
+      this.isMobileNavActive = !this.isMobileNavActive
+
+      document.documentElement.style.overflow = this.isMobileNavActive
           ? "hidden"
           : "auto"
-      },
-    },
+    }
   }
+}
 </script>
 
 <style scoped lang="scss">
-  .light {
-    &#button.active {
-      span {
-        &:before,
-        &:after {
-          background-color: #999;
-        }
-      }
-    }
-
-    &#mobileNavOverlay {
-      .blur {
-        background: white;
-      }
-      ul li {
-        color: #999;
-        a {
-          &.active {
-            color: #eee;
-          }
-          &:hover {
-            color: #eee;
-          }
-        }
-      }
-    }
-  }
-
-  .dark {
-    &#button.active {
-      span {
-        &:before,
-        &:after {
-          background-color: white;
-        }
-      }
-    }
-
-    &#mobileNavOverlay {
-      .blur {
-        background: black;
-      }
-      ul li {
-        color: white;
-        a {
-          &.active {
-            color: #999;
-          }
-          &:hover {
-            color: #999;
-          }
-        }
-      }
-    }
-  }
-
-  #button {
-    width: 35px;
-    height: 25px;
-    cursor: pointer;
-    transform: translateX(0);
-    z-index: 999;
-
+.light {
+  &#button.active {
     span {
-      top: 10px;
-      transition: all 50ms ease-out;
-
       &:before,
       &:after {
-        transition: all 250ms ease-out;
+        background-color: #999;
+      }
+    }
+  }
+
+  &#mobileNavOverlay {
+    .blur {
+      background: white;
+    }
+    ul li {
+      color: #999;
+      a {
+        &.active {
+          color: #eee;
+        }
+        &:hover {
+          color: #eee;
+        }
+      }
+    }
+  }
+}
+
+.dark {
+  &#button.active {
+    span {
+      &:before,
+      &:after {
+        background-color: white;
+      }
+    }
+  }
+
+  &#mobileNavOverlay {
+    .blur {
+      background: black;
+    }
+    ul li {
+      color: white;
+      a {
+        &.active {
+          color: #999;
+        }
+        &:hover {
+          color: #999;
+        }
+      }
+    }
+  }
+}
+
+#button {
+  width: 35px;
+  height: 25px;
+  cursor: pointer;
+  transform: translateX(0);
+  z-index: 999;
+
+  span {
+    top: 10px;
+    transition: all 50ms ease-out;
+
+    &:before,
+    &:after {
+      transition: all 250ms ease-out;
+    }
+    &:before {
+      top: -10px;
+    }
+    &:after {
+      bottom: -10px;
+    }
+  }
+
+  span,
+  span:before,
+  span:after {
+    position: absolute;
+    display: block;
+    height: 3px;
+    width: 35px;
+    content: "";
+    cursor: pointer;
+    background: #999;
+  }
+
+  &.active {
+    span {
+      background-color: transparent;
+      &:before,
+      &:after {
+        top: 0;
       }
       &:before {
-        top: -10px;
+        transform: rotate(45deg);
       }
       &:after {
-        bottom: -10px;
-      }
-    }
-
-    span,
-    span:before,
-    span:after {
-      position: absolute;
-      display: block;
-      height: 3px;
-      width: 35px;
-      content: "";
-      cursor: pointer;
-      background: #999;
-    }
-
-    &.active {
-      span {
-        background-color: transparent;
-        &:before,
-        &:after {
-          top: 0;
-        }
-        &:before {
-          transform: rotate(45deg);
-        }
-        &:after {
-          transform: rotate(-45deg);
-        }
+        transform: rotate(-45deg);
       }
     }
   }
+}
 
-  #mobileNavOverlay {
-    position: absolute;
-    z-index: -1;
-    transition: all ease 0.3s;
+#mobileNavOverlay {
+  position: absolute;
+  z-index: -1;
+  transition: all ease 0.3s;
 
-    &,
+  &,
+  .blur {
+    opacity: 0;
+    height: 100vh;
+    width: 100vw;
+  }
+
+  &.active {
+    display: block;
+    z-index: 800;
+    opacity: 1;
     .blur {
-      opacity: 0;
-      height: 100vh;
-      width: 100vw;
+      opacity: 0.9;
     }
+  }
 
-    &.active {
-      display: block;
-      z-index: 800;
-      opacity: 1;
-      .blur {
-        opacity: 0.9;
-      }
-    }
-
-    ul {
-      position: absolute;
-      top: 50%;
-      left: 50%;
-      list-style-type: none;
-      transform: translateX(-50%) translateY(-50%);
-      li {
-        text-transform: uppercase;
-        font-weight: bold;
-        font-size: 1.5em;
-        text-align: center;
-        a {
-          transition: color ease 0.2s;
-        }
+  ul {
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    list-style-type: none;
+    transform: translateX(-50%) translateY(-50%);
+    li {
+      text-transform: uppercase;
+      font-weight: bold;
+      font-size: 1.5em;
+      text-align: center;
+      a {
+        transition: color ease 0.2s;
       }
     }
   }
+}
 </style>

--- a/src/components/layout/Header.vue
+++ b/src/components/layout/Header.vue
@@ -3,7 +3,7 @@
     <nav class="navbar navbar-expand-lg navbar-light my-5">
       <div class="container">
         <router-link :to="{ name: 'Home' }">
-          <h1>Hacker CV</h1>
+          <h1>{{ content.headline }}</h1>
         </router-link>
 
         <div
@@ -62,6 +62,8 @@
 </template>
 
 <script>
+  import content from "@/ressources/components/layout/header.json"
+
   export default {
     props: {
       /**

--- a/src/components/layout/Header.vue
+++ b/src/components/layout/Header.vue
@@ -9,8 +9,8 @@
         <div
           id="button"
           ref="button"
+          :class="mode"
           @click="toggleMobileNav"
-          :class="{ light: mode === 'light', dark: mode === 'dark' }"
         >
           <span />
         </div>
@@ -30,18 +30,16 @@
     </nav>
   </header>
 
-  <div
-    id="mobileNavOverlay"
-    ref="mobileNavOverlay"
-    :class="{ light: mode === 'light', dark: mode === 'dark' }"
-  >
-    <div class="blur"></div>
+  <div id="mobileNavOverlay" ref="mobileNavOverlay" :class="mode">
+    <div class="blur" />
     <ul class="mb-lg-0">
       <li v-if="renderHomeItemInMobileNav">
         <router-link
           class="nav-link"
           :to="{ name: 'Home' }"
-          :class="{ active: 'Home' === currentRoute }"
+          :class="{
+            active: 'Home' === currentRoute,
+          }"
           @click="toggleMobileNav"
         >
           {{ "Home" }}
@@ -51,7 +49,9 @@
         <router-link
           class="nav-link"
           :to="{ name: view }"
-          :class="{ active: view === currentRoute }"
+          :class="{
+            active: view === currentRoute,
+          }"
           @click="toggleMobileNav"
         >
           {{ view }}
@@ -66,7 +66,7 @@
     props: {
       /**
        * As the top left h1-title in the navigation is not reachable within the mobile navigation overlay, you
-       * may want to additionally render an navigation item for the "Home" route in the mobile navigation overlay.
+       * may want to additionally render a navigation item for the "Home" route in the mobile navigation overlay.
        *
        * Defaults to true.
        */
@@ -99,6 +99,9 @@
         get() {
           return this.$route.name
         },
+      },
+      content: function () {
+        return content
       },
     },
     watch: {
@@ -138,11 +141,12 @@
     }
 
     &#mobileNavOverlay {
-      background: white;
+      .blur {
+        background: white;
+      }
       ul li {
         color: #999;
         a {
-          transition: color ease 0.2s;
           &.active {
             color: #eee;
           }
@@ -165,11 +169,12 @@
     }
 
     &#mobileNavOverlay {
-      background: black;
+      .blur {
+        background: black;
+      }
       ul li {
         color: white;
         a {
-          transition: color ease 0.2s;
           &.active {
             color: #999;
           }
@@ -248,7 +253,7 @@
     &.active {
       display: block;
       z-index: 800;
-      &,
+      opacity: 1;
       .blur {
         opacity: 0.9;
       }
@@ -265,6 +270,9 @@
         font-weight: bold;
         font-size: 1.5em;
         text-align: center;
+        a {
+          transition: color ease 0.2s;
+        }
       }
     }
   }

--- a/src/components/layout/Header.vue
+++ b/src/components/layout/Header.vue
@@ -8,8 +8,8 @@
 
         <div
           id="button"
-          ref="button"
-          :class="mode"
+          class="dark d-lg-none"
+          :class="{ active: isMobileNavActive }"
           @click="toggleMobileNav"
         >
           <span />
@@ -30,10 +30,14 @@
     </nav>
   </header>
 
-  <div id="mobileNavOverlay" ref="mobileNavOverlay" :class="mode">
+  <div
+    id="mobileNavOverlay"
+    class="dark d-lg-none"
+    :class="{ active: isMobileNavActive }"
+  >
     <div class="blur" />
     <ul class="mb-lg-0">
-      <li v-if="renderHomeItemInMobileNav">
+      <li>
         <router-link
           class="nav-link"
           :to="{ name: 'Home' }"
@@ -65,29 +69,6 @@
   import content from "@/ressources/components/layout/header.json"
 
   export default {
-    props: {
-      /**
-       * As the top left h1-title in the navigation is not reachable within the mobile navigation overlay, you
-       * may want to additionally render a navigation item for the "Home" route in the mobile navigation overlay.
-       *
-       * Defaults to true.
-       */
-      renderHomeItemInMobileNav: {
-        type: Boolean,
-        default: true,
-      },
-      /**
-       * You can choose between a light mode and a dark mode.
-       * For now, the mode only applies to the mobile navigation overlay.
-       *
-       * Defaults to "light".
-       */
-      mode: {
-        type: String,
-        validator: (value) => ["light", "dark"].includes(value),
-        default: "light",
-      },
-    },
     data: function () {
       return {
         isMobileNavActive: false,
@@ -106,32 +87,18 @@
         return content
       },
     },
-    watch: {
-      /** Disables scrolling while mobile navigation overlay is shown. */
-      isMobileNavActive: function (currentValue) {
-        document.documentElement.style.overflow = currentValue
-          ? "hidden"
-          : "auto"
-      },
-    },
     methods: {
       toggleMobileNav: function () {
-        this.$refs.button.classList.toggle("active")
-        this.$refs.mobileNavOverlay.classList.toggle("active")
         this.isMobileNavActive = !this.isMobileNavActive
+        document.documentElement.style.overflow = this.isMobileNavActive
+          ? "hidden"
+          : "auto"
       },
     },
   }
 </script>
 
 <style scoped lang="scss">
-  @media (min-width: 992px) {
-    #button,
-    #mobileNavOverlay {
-      display: none;
-    }
-  }
-
   .light {
     &#button.active {
       span {

--- a/src/ressources/components/layout/header.json
+++ b/src/ressources/components/layout/header.json
@@ -1,0 +1,3 @@
+{
+    "headline": "Hacker CV"
+}


### PR DESCRIPTION
### Neue Mobile Fullscreen Navigation
#### Feature
- Ersetzt den alten Bootstrap mobile-only Navigation Button durch einen neuen, eigenen Navigation Button. Dieser ist sichtbar bis `>991px`, das selbe Verhalten wie zuvor auch.
- Bei Klick auf den neuen Button wird ein Fullscreen Overlay (sieht ein wenig so aus wie ein Modal) geöffnet. 
- Für dieses Overlay wurden zusätzlich zwei Modi mit eingeführt: Ein Dark- und ein Light-Mode (Default: `"light"`, da es besser zum derzeitigen Default-Design passt).
- Zusätzlich wurde noch eine `header.json` erstellt, welche Content für die Header Component beinhaltet.

#### To be discussed
- Das Overlay hat aktuell immer (in beiden Modi) eine leichte Transparenz (`opacity: 0.9`). Eine zusätzliche Möglichkeit wäre die Transparenz optional zu machen bzw. über Props der `Header.vue` zu steuern. Ohne Transparenz sieht es imho auch nicht schlecht aus, vor allem im Light-Mode
- Außerdem habe ich einen Änderungsvorschlag für zwei ESLint-Regeln gepusht.